### PR TITLE
Fix: Create releases in release workflow only

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -50,14 +50,3 @@ jobs:
       - name: "Docker Logout"
         if: "'refs/heads/main' == github.ref || startsWith(github.ref, 'refs/tags/')"
         run: "docker logout"
-
-      - name: "Create release"
-        if: "startsWith(github.ref, 'refs/tags/')"
-        uses: "actions/create-release@v1.1.3"
-        env:
-          GITHUB_TOKEN: "${{ secrets.ERGEBNIS_BOT_TOKEN }}"
-        with:
-          draft: false
-          prerelease: false
-          release_name: "${{ steps.determine-tag.outputs.tag }}"
-          tag_name: "${{ steps.determine-tag.outputs.tag }}"


### PR DESCRIPTION
This PR

* [x] creates releases in the release workflow only