### PR TITLE
Fix: Do not use set-env to set COMPOSER_ROOT_VERSION variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.2.0...main`][0.2.0...main].
+For a full diff see [`0.2.1...main`][0.2.1...main].
+
+## [`0.2.1`][0.2.1]
+
+For a full diff see [`0.2.0...0.2.1`][0.2.0...0.2.1].
+
+### Changed
+
+* Stopped using `set-env` to set `COMPOSER_ROOT_VERSION` environment variable ([#26]), by [@localheinz]
 
 ## [`0.2.0`][0.2.0]
 
@@ -49,17 +57,20 @@ For a full diff see [`b25b879...0.1.0`][b25b879...0.1.0].
 [0.1.2]: https://github.com/ergebnis/composer-root-version-action/releases/tag/0.1.2
 [0.1.3]: https://github.com/ergebnis/composer-root-version-action/releases/tag/0.1.3
 [0.2.0]: https://github.com/ergebnis/composer-root-version-action/releases/tag/0.2.0
+[0.2.1]: https://github.com/ergebnis/composer-root-version-action/releases/tag/0.2.1
 
 [b25b879...0.1.0]: https://github.com/ergebnis/composer-root-version-action/compare/b25b879...0.1.0
 [0.1.0...0.1.1]: https://github.com/ergebnis/composer-root-version-action/compare/0.1.0...0.1.1
 [0.1.1...0.1.2]: https://github.com/ergebnis/composer-root-version-action/compare/0.1.1...0.1.2
 [0.1.2...0.1.3]: https://github.com/ergebnis/composer-root-version-action/compare/0.1.2...0.1.3
 [0.1.3...0.2.0]: https://github.com/ergebnis/composer-root-version-action/compare/0.1.3...0.2.0
-[0.2.0...main]: https://github.com/ergebnis/composer-root-version-action/compare/0.2.0...main
+[0.2.0...0.2.1]: https://github.com/ergebnis/composer-root-version-action/compare/0.2.0...0.2.1
+[0.2.1...main]: https://github.com/ergebnis/composer-root-version-action/compare/0.2.1...main
 
 [#7]: https://github.com/ergebnis/composer-root-version-action/pull/7
 [#8]: https://github.com/ergebnis/composer-root-version-action/pull/8
 [#9]: https://github.com/ergebnis/composer-root-version-action/pull/9
 [#11]: https://github.com/ergebnis/composer-root-version-action/pull/11
+[#26]: https://github.com/ergebnis/composer-root-version-action/pull/26
 
 [@localheinz]: https://github.com/localheinz

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,5 +23,5 @@ echo "Determined composer root version for branch \"${BRANCH}\" in \"${PATH_TO_C
 
 if [[ true = "${GITHUB_ACTIONS}" ]]; then
     echo "Setting COMPOSER_ROOT_VERSION environment variable to \"${COMPOSER_ROOT_VERSION}\"."
-    echo "::set-env name=COMPOSER_ROOT_VERSION::${COMPOSER_ROOT_VERSION}"
+    echo "COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION}" >> "${GITHUB_ENV}"
 fi


### PR DESCRIPTION
This PR

* [x] stops using `set-env` to set the `COMPOSER_ROOT_VERSION` environment variable

💁‍♂️ For reference, see https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/.