### PR TITLE
Enhancement: Use composite action from `ergebnis/.github`

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: "Run GitHub Action when composer.json is not present and path is not specified"
         continue-on-error: true
-        uses: "./"
+        uses: "ergebnis/.github/actions/composer/determine-root-version@1.5.0"
 
       - name: "Verify that COMPOSER_ROOT_VERSION environment variable has not been set"
         run: |
@@ -53,9 +53,9 @@ jobs:
 
       - name: "Run GitHub Action when composer.json is not present"
         continue-on-error: true
-        uses: "./"
+        uses: "ergebnis/.github/actions/composer/determine-root-version@1.5.0"
         with:
-          path: ".build/composer-json/present/no"
+          working-directory: ".build/composer-json/present/no"
 
       - name: "Verify that COMPOSER_ROOT_VERSION environment variable has not been set"
         run: |
@@ -68,9 +68,9 @@ jobs:
           echo "COMPOSER_ROOT_VERSION environment variable has not been set."
 
       - name: "Run GitHub Action when composer.json is present but does not have branch-alias defined"
-        uses: "./"
+        uses: "ergebnis/.github/actions/composer/determine-root-version@1.5.0"
         with:
-          path: ".build/composer-json/present/yes/branch-alias/defined/no"
+          working-directory: ".build/composer-json/present/yes/branch-alias/defined/no"
 
       - name: "Verify that COMPOSER_ROOT_VERSION environment variable has not been set"
         run: |
@@ -83,10 +83,10 @@ jobs:
           echo "COMPOSER_ROOT_VERSION environment variable has not been set."
 
       - name: "Run GitHub Action when composer.json is present but does not have specified branch-alias defined"
-        uses: "./"
+        uses: "ergebnis/.github/actions/composer/determine-root-version@1.5.0"
         with:
-          path: ".build/composer-json/present/yes/branch-alias/defined/yes"
           branch: "foo"
+          working-directory: ".build/composer-json/present/yes/branch-alias/defined/yes"
 
       - name: "Verify that COMPOSER_ROOT_VERSION environment variable has not been set"
         run: |
@@ -99,10 +99,10 @@ jobs:
           echo "COMPOSER_ROOT_VERSION environment variable has not been set."
 
       - name: "Run GitHub Action when composer.json is present and has specified branch-alias defined"
-        uses: "./"
+        uses: "ergebnis/.github/actions/composer/determine-root-version@1.5.0"
         with:
-          path: ".build/composer-json/present/yes/branch-alias/defined/yes"
           branch: "bar"
+          working-directory: ".build/composer-json/present/yes/branch-alias/defined/yes"
 
       - name: "Verify that COMPOSER_ROOT_VERSION environment variable has been set"
         run: |
@@ -123,9 +123,9 @@ jobs:
           EXPECTED_COMPOSER_ROOT_VERSION: "1.0-dev"
 
       - name: "Run GitHub Action when composer.json is present and has default branch-alias defined"
-        uses: "./"
+        uses: "ergebnis/.github/actions/composer/determine-root-version@1.5.0"
         with:
-          path: ".build/composer-json/present/yes/branch-alias/defined/yes"
+          working-directory: ".build/composer-json/present/yes/branch-alias/defined/yes"
 
       - name: "Verify that COMPOSER_ROOT_VERSION environment variable has been set"
         run: |


### PR DESCRIPTION
This pull request

- [x] uses the composite action from `ergebnis/.github`

Related to #54.